### PR TITLE
90% - Reset state correctly at end of video

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "MediaEvents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/talis/linear-video-analytics-spike",
   "authors": [
     "Mark Wallsgrove <mw@talis.com>"

--- a/mediaEvents.js
+++ b/mediaEvents.js
@@ -169,8 +169,6 @@ var MediaEvents = (function () {
             this.playedFrom = this.lastKnownPlaybackTime;
         },
         end: function () {
-            this.lastKnownPlaybackTime = this.endTime;
-
             this.flushEventFn({
                 start: this.playedFrom,
                 end: this.endTime,

--- a/mediaEvents.js
+++ b/mediaEvents.js
@@ -85,7 +85,7 @@ var MediaEvents = (function () {
                 this.expectedInterval = this.intervalLength;
                 this.playedFrom = 0;
             } else if (hasSeeked && playbackDiff > 0 && playbackTime - this.lastKnownPlaybackTime >= 1000) {
-                // seeked forward 
+                // seeked forward
                 this.flushEventFn({
                     start: this.lastKnownPlaybackTime,
                     end: playbackTime,
@@ -179,6 +179,11 @@ var MediaEvents = (function () {
                 type: 'segment',
                 premature: true
             });
+
+            // Reset state at end of video
+            this.lastKnownPlaybackTime = 0;
+            this.lastKnownTime = -1;
+            this.playedFrom = 0;
         }
     };
 


### PR DESCRIPTION
Needed as part of talis/talis.com-app#942 and talis/talis.com-app#883

State was not getting reset correctly at the end of the video.
If you played the video to the end once (and let it stop and reset to start), if you then scrub to 5 seconds and let it play through to 11 seconds, you'd get a segment logged for the full first 10 seconds whereas you only started watching from 5 seconds.

This was never a problem on first view of the video, _only_ when it's reached the end once as state wasn't getting reset correctly.